### PR TITLE
StockController -  protected property - swapped Purchase for purchase

### DIFF
--- a/app/StockPurchase.php
+++ b/app/StockPurchase.php
@@ -12,7 +12,7 @@ class StockPurchase extends Model
      *
      * @var array
      */
-    protected $table = 'Purchase';
+    protected $table = 'purchase';
     protected $primaryKey = 'ID';
 
     protected $fillable = [
@@ -27,8 +27,5 @@ class StockPurchase extends Model
     {
         return $this->belongsTo('App\Supplyer', 'supplyerID', 'id')->select(array('id', 'name','Adress','contact','total_balance','paid'));
     }
-
-
-
 
 }


### PR DESCRIPTION
Original line : `protected $table = 'Purchase';`

> Error produced: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.Purchase' doesn't exist

Modified: `protected $table = 'purchase';`

Error resolved